### PR TITLE
Allow the repository to be published via GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[The tiler ](Browser%20Tiler%20self%20contained%20V1.html)
+Click on the [The Tile Browser](Browser%20Tiler%20self%20contained%20V1.html) to try the tile browser that was created by Peter Rinjii

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[The tiler ](Browser%20Tiler%20self%20contained%20V1.html)


### PR DESCRIPTION
If you configure the repo to publish to GitHub Pages, this README serves as a landing page from which a user can navigate to the tiler.